### PR TITLE
Feat: 리이슈, 로그아웃, 블랙리스트 API 구현

### DIFF
--- a/src/main/java/cotato/growingpain/auth/controller/AuthController.java
+++ b/src/main/java/cotato/growingpain/auth/controller/AuthController.java
@@ -7,8 +7,6 @@ import cotato.growingpain.security.jwt.dto.response.ReissueResponse;
 import cotato.growingpain.auth.service.AuthService;
 import cotato.growingpain.security.jwt.Token;
 import jakarta.validation.Valid;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/cotato/growingpain/auth/controller/AuthController.java
+++ b/src/main/java/cotato/growingpain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package cotato.growingpain.auth.controller;
 
 import cotato.growingpain.auth.dto.request.JoinRequest;
+import cotato.growingpain.auth.dto.request.LogoutRequest;
 import cotato.growingpain.security.jwt.dto.request.ReissueRequest;
 import cotato.growingpain.security.jwt.dto.response.ReissueResponse;
 import cotato.growingpain.auth.service.AuthService;
@@ -40,5 +41,11 @@ public class AuthController {
     @PostMapping("/reissue")
     public ResponseEntity<ReissueResponse> tokenRefresh(@RequestBody ReissueRequest request) {
         return ResponseEntity.ok(authService.tokenReissue(request));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@RequestBody LogoutRequest logoutRequest) {
+        authService.logout(logoutRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/cotato/growingpain/auth/controller/AuthController.java
+++ b/src/main/java/cotato/growingpain/auth/controller/AuthController.java
@@ -30,12 +30,7 @@ public class AuthController {
     public ResponseEntity<?> joinAuth(@RequestBody @Valid JoinRequest request) {
         log.info("[회원 가입 컨트롤러]: {}", request.email());
         Token token = authService.createLoginInfo(request);
-
-        Map<String, String> response = new HashMap<>();
-        response.put("accessToken", token.getAccessToken());
-        response.put("refreshToken", token.getRefreshToken());
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(token);
     }
 
     @PostMapping("/reissue")

--- a/src/main/java/cotato/growingpain/auth/domain/BlackList.java
+++ b/src/main/java/cotato/growingpain/auth/domain/BlackList.java
@@ -1,0 +1,20 @@
+package cotato.growingpain.auth.domain;
+
+import jakarta.persistence.Id;
+import java.util.concurrent.TimeUnit;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@Builder
+@RedisHash(value = "blackList")
+public class BlackList {
+
+    @Id
+    String id;
+
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private Long ttl;
+}

--- a/src/main/java/cotato/growingpain/auth/dto/request/LogoutRequest.java
+++ b/src/main/java/cotato/growingpain/auth/dto/request/LogoutRequest.java
@@ -1,0 +1,7 @@
+package cotato.growingpain.auth.dto.request;
+
+public record LogoutRequest(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/cotato/growingpain/auth/repository/BlackListRepository.java
+++ b/src/main/java/cotato/growingpain/auth/repository/BlackListRepository.java
@@ -1,0 +1,9 @@
+package cotato.growingpain.auth.repository;
+
+import cotato.growingpain.auth.domain.BlackList;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BlackListRepository extends CrudRepository<BlackList, String> {
+}

--- a/src/main/java/cotato/growingpain/auth/service/AuthService.java
+++ b/src/main/java/cotato/growingpain/auth/service/AuthService.java
@@ -49,22 +49,31 @@ public class AuthService {
         memberRepository.save(newMember);
 
         // 회원가입 성공 후 토큰 생성 및 반환
-        return jwtTokenProvider.createToken(request.email(), "ROLE_USER");
+        Token token = jwtTokenProvider.createToken(request.email(), "ROLE_USER");
+
+        // 리프레시 토큰을 데이터베이스에 저장
+        RefreshTokenEntity refreshTokenEntity = RefreshTokenEntity
+                .builder()
+                .email(request.email())
+                .refreshToken(token.getRefreshToken())
+                .build();
+        refreshTokenRepository.save(refreshTokenEntity);
+
+        return token;
     }
 
     @Transactional
     public ReissueResponse tokenReissue(ReissueRequest request) {
 
-        String memberId = jwtTokenProvider.getEmail(request.refreshToken());
+        String email = jwtTokenProvider.getEmail(request.refreshToken());
         String role = jwtTokenProvider.getRole(request.refreshToken());
 
-        log.info("재발급 요청된 이메일: {}", memberId);
+        log.info("재발급 요청된 이메일: {}", email);
+        log.info("재발급 요청된 role: {}", role);
 
         // 데이터베이스에서 이메일 확인 로그 추가
-        RefreshTokenEntity findToken = refreshTokenRepository.findById(memberId)
+        RefreshTokenEntity findToken = refreshTokenRepository.findById(email)
                 .orElseThrow(() -> new AppException(ErrorCode.EMAIL_NOT_FOUND));
-
-        //log.info("DB에서 찾은 리프레시 토큰: {}", request);
 
         if (jwtTokenProvider.isExpired(request.refreshToken())) {
             throw new AppException(ErrorCode.TOKEN_EXPIRED);
@@ -75,11 +84,12 @@ public class AuthService {
             throw new AppException(ErrorCode.REFRESH_TOKEN_NOT_EXIST);
         }
 
-        Token token = jwtTokenProvider.createToken(memberId, role);
+        Token token = jwtTokenProvider.createToken(email, role);
         findToken.updateRefreshToken(token.getRefreshToken());
         refreshTokenRepository.save(findToken);
-        log.info("재발급 된 액세스 토큰: {}", token.getRefreshToken());
-        return ReissueResponse.from(token.getAccessToken(), token.getRefreshToken());
+
+        log.info("재발급 된 액세스 토큰: {}", token.getAccessToken());
+        return ReissueResponse.from(token.getAccessToken());
     }
 
     @Transactional

--- a/src/main/java/cotato/growingpain/auth/service/AuthService.java
+++ b/src/main/java/cotato/growingpain/auth/service/AuthService.java
@@ -93,7 +93,7 @@ public class AuthService {
 
         log.info("재발급 된 액세스 토큰: {}", token.getAccessToken());
         log.info("재발급 된 refresh 토큰: {}", token.getRefreshToken());
-        return ReissueResponse.from(token.getAccessToken());
+        return ReissueResponse.from(token.getAccessToken(),token.getRefreshToken());
     }
 
     @Transactional

--- a/src/main/java/cotato/growingpain/auth/service/AuthService.java
+++ b/src/main/java/cotato/growingpain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package cotato.growingpain.auth.service;
 
 import cotato.growingpain.auth.dto.request.JoinRequest;
+import cotato.growingpain.auth.dto.request.LogoutRequest;
 import cotato.growingpain.security.jwt.dto.request.ReissueRequest;
 import cotato.growingpain.security.jwt.dto.response.ReissueResponse;
 import cotato.growingpain.common.exception.AppException;
@@ -79,5 +80,17 @@ public class AuthService {
         refreshTokenRepository.save(findToken);
         log.info("재발급 된 액세스 토큰: {}", token.getRefreshToken());
         return ReissueResponse.from(token.getAccessToken(), token.getRefreshToken());
+    }
+
+    @Transactional
+    public void logout(LogoutRequest request) {
+        deleteRefreshToken(request.refreshToken());
+        log.info("삭제 요청된 refreshToken: {}", request.refreshToken());
+    }
+
+    private void deleteRefreshToken(String refreshToken) {
+        RefreshTokenEntity refreshTokenEntity = refreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow();
+        refreshTokenRepository.delete(refreshTokenEntity);
     }
 }

--- a/src/main/java/cotato/growingpain/common/exception/ErrorCode.java
+++ b/src/main/java/cotato/growingpain/common/exception/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
     JWT_NOT_EXISTS(HttpStatus.NO_CONTENT, "Jwt 토큰이 존재하지 않습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 유저를 찾을 수 없습니다."),
     TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "토큰이 만료되었습니다."),
-    REFRESH_TOKEN_NOT_EXIST(HttpStatus.UNAUTHORIZED, "해당 refresh 토큰이 DB에 존재하지 않습니다.");
+    REFRESH_TOKEN_NOT_EXIST(HttpStatus.UNAUTHORIZED, "해당 refresh 토큰이 DB에 존재하지 않습니다."),
+    REISSUE_FAIL(HttpStatus.UNAUTHORIZED, "액세스 토큰 재발급 요청 실패");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/cotato/growingpain/config/RedisConfig.java
+++ b/src/main/java/cotato/growingpain/config/RedisConfig.java
@@ -5,10 +5,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableRedisRepositories
 public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String host;
@@ -19,5 +20,16 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
     }
 }

--- a/src/main/java/cotato/growingpain/config/SecurityConfig.java
+++ b/src/main/java/cotato/growingpain/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import cotato.growingpain.security.jwt.filter.JwtAuthorizationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -23,6 +24,15 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
+
+    private final String[] WHITE_LIST = {
+            "/swagger-ui/**",
+            "/api/auth/**",
+            "/v3/api-docs/**"
+    };
+
+    private final String[] REQUIRED_AUTHENTICATE = {
+    };
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -42,9 +52,9 @@ public class SecurityConfig {
                 .addFilter(new JwtAuthenticationFilter(authenticationManager, jwtTokenProvider, refreshTokenRepository))
                 .addFilterBefore(new JwtAuthorizationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers("/api/auth/join").permitAll()
-                        .requestMatchers( "/swagger-ui/**").permitAll()
-                        .requestMatchers( "/v3/api-docs/**").permitAll()
+                        .requestMatchers(WHITE_LIST).permitAll()
+                        .requestMatchers(HttpMethod.GET, REQUIRED_AUTHENTICATE).authenticated()
+                        .requestMatchers(HttpMethod.GET).permitAll()
                         .anyRequest().authenticated()
                 );
         return http.build();

--- a/src/main/java/cotato/growingpain/security/RefreshTokenRepository.java
+++ b/src/main/java/cotato/growingpain/security/RefreshTokenRepository.java
@@ -2,10 +2,9 @@ package cotato.growingpain.security;
 
 import cotato.growingpain.security.jwt.RefreshTokenEntity;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, String> {
-    Optional<RefreshTokenEntity> findByRefreshToken(String refreshToken);
+public interface RefreshTokenRepository extends CrudRepository<RefreshTokenEntity, String> {
 }

--- a/src/main/java/cotato/growingpain/security/RefreshTokenRepository.java
+++ b/src/main/java/cotato/growingpain/security/RefreshTokenRepository.java
@@ -1,9 +1,11 @@
 package cotato.growingpain.security;
 
 import cotato.growingpain.security.jwt.RefreshTokenEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, String> {
+    Optional<RefreshTokenEntity> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/cotato/growingpain/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/cotato/growingpain/security/jwt/JwtTokenProvider.java
@@ -82,4 +82,9 @@ public class JwtTokenProvider {
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }
+
+    public Long getExpiration(String token) {
+        Claims claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+        return claims.getExpiration().getTime() - new Date().getTime();
+    }
 }

--- a/src/main/java/cotato/growingpain/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/cotato/growingpain/security/jwt/JwtTokenProvider.java
@@ -5,12 +5,13 @@ import cotato.growingpain.common.exception.ErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
@@ -25,6 +26,7 @@ public class JwtTokenProvider {
     Long refreshExpiration;
 
     public boolean validateToken(String accessToken) {
+        log.info("Validating access token: {}", accessToken);
         if (accessToken.isEmpty()) {
             throw new AppException(ErrorCode.JWT_NOT_EXISTS);
         }
@@ -63,7 +65,7 @@ public class JwtTokenProvider {
         claims.put("role",authority);
         return Jwts.builder()
                 .setClaims(claims)
-                .setIssuedAt(new Date())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + accessExpiration))
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
@@ -75,7 +77,7 @@ public class JwtTokenProvider {
         claims.put("role",authority);
         return Jwts.builder()
                 .setClaims(claims)
-                .setIssuedAt(new Date())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + refreshExpiration))
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();

--- a/src/main/java/cotato/growingpain/security/jwt/RefreshTokenEntity.java
+++ b/src/main/java/cotato/growingpain/security/jwt/RefreshTokenEntity.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 @Builder
+//@RedisHash(value = "jwtToken", timeToLive = 60 * 60 * 24 * 3)
 public class RefreshTokenEntity {
 
     @Id

--- a/src/main/java/cotato/growingpain/security/jwt/RefreshTokenEntity.java
+++ b/src/main/java/cotato/growingpain/security/jwt/RefreshTokenEntity.java
@@ -3,6 +3,7 @@ package cotato.growingpain.security.jwt;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,10 +11,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Builder
 public class RefreshTokenEntity {
 
     @Id
-    private String id; // email이 id로 사용됨
+    private String email; // email이 id로 사용됨
 
     private String refreshToken;
 

--- a/src/main/java/cotato/growingpain/security/jwt/dto/response/ReissueResponse.java
+++ b/src/main/java/cotato/growingpain/security/jwt/dto/response/ReissueResponse.java
@@ -1,9 +1,10 @@
 package cotato.growingpain.security.jwt.dto.response;
 
 public record ReissueResponse(
-        String accessToken
+        String accessToken,
+        String refreshToken
 ) {
-    public static ReissueResponse from(String accessToken) {
-        return new ReissueResponse(accessToken);
+    public static ReissueResponse from(String accessToken, String refreshToken) {
+        return new ReissueResponse(accessToken, refreshToken);
     }
 }

--- a/src/main/java/cotato/growingpain/security/jwt/dto/response/ReissueResponse.java
+++ b/src/main/java/cotato/growingpain/security/jwt/dto/response/ReissueResponse.java
@@ -1,11 +1,9 @@
 package cotato.growingpain.security.jwt.dto.response;
 
 public record ReissueResponse(
-        String accessToken,
-        String refreshToken
+        String accessToken
 ) {
-
-    public static ReissueResponse from(String accessToken, String refreshToken) {
-        return new ReissueResponse(accessToken, refreshToken);
+    public static ReissueResponse from(String accessToken) {
+        return new ReissueResponse(accessToken);
     }
 }

--- a/src/main/java/cotato/growingpain/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/cotato/growingpain/security/jwt/filter/JwtAuthenticationFilter.java
@@ -11,7 +11,6 @@ import cotato.growingpain.security.jwt.RefreshTokenEntity;
 import cotato.growingpain.security.jwt.Token;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -70,11 +69,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         refreshTokenRepository.save(
                 new RefreshTokenEntity(authDetails.getMember().getEmail(), token.getRefreshToken()));
 
-        Cookie cookie = new Cookie("refreshToken", token.getRefreshToken());
-        cookie.setPath("/");
-        cookie.setMaxAge(refreshTokenAge);
-        cookie.setSecure(true);
-        response.addCookie(cookie);
         log.info("로그인 성공, JWT 토큰 생성");
     }
 }

--- a/src/main/java/cotato/growingpain/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/cotato/growingpain/security/jwt/filter/JwtAuthenticationFilter.java
@@ -66,8 +66,9 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String accessToken = token.getAccessToken();
         response.addHeader("accessToken", accessToken);
 
-        refreshTokenRepository.save(
-                new RefreshTokenEntity(authDetails.getMember().getEmail(), token.getRefreshToken()));
+        RefreshTokenEntity refreshTokenEntity  = new RefreshTokenEntity(authDetails.getMember().getEmail(), token.getRefreshToken());
+        refreshTokenEntity.updateRefreshToken(token.getRefreshToken());
+        refreshTokenRepository.save(refreshTokenEntity);
 
         log.info("로그인 성공, JWT 토큰 생성");
     }

--- a/src/main/java/cotato/growingpain/security/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/cotato/growingpain/security/jwt/filter/JwtAuthorizationFilter.java
@@ -37,8 +37,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private void getAuthentication(String accessToken) {
         log.info("getAuthentication");
-            String email = jwtTokenProvider.getEmail(accessToken);
-            String role = jwtTokenProvider.getRole(accessToken);
+        String email = jwtTokenProvider.getEmail(accessToken);
+        String role = jwtTokenProvider.getRole(accessToken);
         log.info("Member Role: {}", role);
 
         Authentication authenticationToken = new UsernamePasswordAuthenticationToken(email, "",
@@ -56,6 +56,11 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     }
 
     public String getBearer(String authorizationHeader) {
-        return authorizationHeader.replace("Bearer", "");
+        return authorizationHeader.replace("Bearer ", "");
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return super.shouldNotFilter(request);
     }
 }

--- a/src/main/java/cotato/growingpain/security/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/cotato/growingpain/security/jwt/filter/JwtAuthorizationFilter.java
@@ -7,21 +7,21 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
+@Component
+@RequiredArgsConstructor
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
-
-    public JwtAuthorizationFilter(JwtTokenProvider jwtTokenProvider) {
-        this.jwtTokenProvider = jwtTokenProvider;
-    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {


### PR DESCRIPTION
## ⛓️ Related Issues
관련 이슈
- https://github.com/IT-Cotato/9th-Growing-Pain-BE/issues/28#issue-2384060930
- https://github.com/IT-Cotato/9th-Growing-Pain-BE/issues/32#issue-2387993302

## ☁️ what to do 
작업 내용에 대한 요약을 적어주세요.
- 리이슈, 로그아웃, 블랙리스트 API 구현 완료했습니다
- _**RefreshTokenEntity에 redis 관련 어노테이션 넣으려고 했는데 오류가 뜹니다..ㅠ**_
