### PR TITLE
Feat: 비밀번호 찾을 시 임시 비밀번호 발급되는 기능 구현

### DIFF
--- a/src/main/java/cotato/growingpain/auth/controller/AuthController.java
+++ b/src/main/java/cotato/growingpain/auth/controller/AuthController.java
@@ -1,7 +1,9 @@
 package cotato.growingpain.auth.controller;
 
+import cotato.growingpain.auth.dto.request.ChangePasswordRequest;
 import cotato.growingpain.auth.dto.request.JoinRequest;
 import cotato.growingpain.auth.dto.request.LogoutRequest;
+import cotato.growingpain.auth.dto.response.ChangePasswordResponse;
 import cotato.growingpain.security.jwt.dto.request.ReissueRequest;
 import cotato.growingpain.security.jwt.dto.response.ReissueResponse;
 import cotato.growingpain.auth.service.AuthService;
@@ -37,8 +39,14 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(@RequestBody LogoutRequest logoutRequest) {
-        authService.logout(logoutRequest);
+    public ResponseEntity<?> logout(@RequestBody LogoutRequest request) {
+        authService.logout(request);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/change-password")
+    public ResponseEntity<ChangePasswordResponse> changePassword(@RequestBody ChangePasswordRequest request){
+        log.info("[비밀번호 찾기 컨트롤러]: {}", request.email());
+        return ResponseEntity.ok(authService.changePassword(request));
     }
 }

--- a/src/main/java/cotato/growingpain/auth/dto/request/ChangePasswordRequest.java
+++ b/src/main/java/cotato/growingpain/auth/dto/request/ChangePasswordRequest.java
@@ -1,0 +1,6 @@
+package cotato.growingpain.auth.dto.request;
+
+public record ChangePasswordRequest(
+    String email
+) {
+}

--- a/src/main/java/cotato/growingpain/auth/dto/response/ChangePasswordResponse.java
+++ b/src/main/java/cotato/growingpain/auth/dto/response/ChangePasswordResponse.java
@@ -1,0 +1,6 @@
+package cotato.growingpain.auth.dto.response;
+
+public record ChangePasswordResponse(
+    String password
+) {
+}

--- a/src/main/java/cotato/growingpain/auth/service/ValidateService.java
+++ b/src/main/java/cotato/growingpain/auth/service/ValidateService.java
@@ -18,11 +18,21 @@ public class ValidateService {
     private static final String PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,16}$";
     private final MemberRepository memberRepository;
 
+
     public void checkPasswordPattern(String password) {
         Pattern pattern = Pattern.compile(PASSWORD_PATTERN);
         Matcher matcher = pattern.matcher(password);
         if (!matcher.matches()) {
             throw new AppException(ErrorCode.INVALID_PASSWORD);
+        }
+    }
+
+    public boolean isValidPassword(String password) {
+        try {
+            checkPasswordPattern(password);
+            return true;
+        } catch (AppException e) {
+            return false;
         }
     }
 

--- a/src/main/java/cotato/growingpain/member/domain/entity/Member.java
+++ b/src/main/java/cotato/growingpain/member/domain/entity/Member.java
@@ -122,4 +122,8 @@ public class Member extends BaseTimeEntity {
         this.field = field;
         this.belong = belong;
     }
+
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
+    }
 }


### PR DESCRIPTION
## ⛓️ Related Issues
관련 이슈
- https://github.com/IT-Cotato/9th-Growing-Pain-BE/issues/46#issue-2412746997

## ☁️ what to do 
작업 내용에 대한 요약을 적어주세요.
- 사용자가 비밀번호 찾기를 누를 경우, 임시 비밀번호가 화면에 보임. DB에서도 member_password가 임시 비밀번호로 변경됨


## ✅ How to Test
변경된 코드를 테스트하는 방법을 설명해주세요. 
- auth에 accessToken 넣고, body에는 email 적으면 잘 나옴
