### PR TITLE
refactor: 게시글 목록 반환 기능 수정

### DIFF
--- a/src/main/java/cotato/growingpain/post/controller/PostController.java
+++ b/src/main/java/cotato/growingpain/post/controller/PostController.java
@@ -54,7 +54,7 @@ public class PostController {
     public Response<PostListResponse> getPostsByMemberId(@AuthenticationPrincipal Long memberId) {
         List<Post> posts = postService.getPostsByMemberId(memberId);
         log.info("{}가 등록한 게시글 목록", memberId);
-        PostListResponse postListResponse = new PostListResponse(posts);
+        PostListResponse postListResponse = PostListResponse.from(posts);
         return Response.createSuccess("사용자의 게시글 목록 조회 완료", postListResponse);
     }
 
@@ -70,7 +70,7 @@ public class PostController {
         } else {
             posts = postService.getPostsByCategory(category);
         }
-        PostListResponse postListResponse = new PostListResponse(posts);
+        PostListResponse postListResponse = PostListResponse.from(posts);
         return Response.createSuccess(category == PostCategory.ALL ? "전체 게시글 조회 완료" : "카테고리별 게시글 목록 조회 완료", postListResponse);
     }
 

--- a/src/main/java/cotato/growingpain/post/controller/PostSaveController.java
+++ b/src/main/java/cotato/growingpain/post/controller/PostSaveController.java
@@ -60,7 +60,7 @@ public class PostSaveController {
     public Response<PostListResponse> getSavedPosts(@AuthenticationPrincipal Long memberId) {
         log.info("사용자가 저장한 게시글 목록 요청: memberId {}", memberId);
         List<Post> savedPosts= postSaveService.getSavedPosts(memberId);
-        PostListResponse postListResponse = new PostListResponse(savedPosts);
+        PostListResponse postListResponse = PostListResponse.from(savedPosts);
         return Response.createSuccess("저장한 게시글 목록 조회 완료", postListResponse);
     }
 }

--- a/src/main/java/cotato/growingpain/post/dto/response/PostListResponse.java
+++ b/src/main/java/cotato/growingpain/post/dto/response/PostListResponse.java
@@ -3,7 +3,13 @@ package cotato.growingpain.post.dto.response;
 import cotato.growingpain.post.domain.entity.Post;
 import java.util.List;
 
-public record PostListResponse(List<Post> posts) {
-
+public record PostListResponse(
+        List<PostResponse> posts
+) {
+    public static PostListResponse from(List<Post> posts) {
+        List<PostResponse> postResponses = posts.stream()
+                .map(PostResponse::from)
+                .toList();
+        return new PostListResponse(postResponses);
+    }
 }
-

--- a/src/main/java/cotato/growingpain/post/dto/response/PostResponse.java
+++ b/src/main/java/cotato/growingpain/post/dto/response/PostResponse.java
@@ -1,0 +1,33 @@
+package cotato.growingpain.post.dto.response;
+
+import cotato.growingpain.post.domain.entity.Post;
+
+public record PostResponse(
+        Long postId,
+        String title,
+        String content,
+        String postImageUrl,
+        String parentCategory,
+        String subCategory,
+        Integer likeCount,
+        Boolean isDeleted,
+        String memberNickname,
+        String ProfileImage,
+        String memberField
+) {
+    public static PostResponse from(Post post) {
+        return new PostResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getImageUrl(),
+                post.getParentCategory() != null ? post.getParentCategory().name() : null,
+                post.getSubCategory() != null ? post.getSubCategory().name() : null,
+                post.getLikeCount(),
+                post.isDeleted(),
+                post.getMember().getName(),
+                post.getMember().getProfileImageUrl(),
+                post.getMember().getField()
+        );
+    }
+}

--- a/src/main/java/cotato/growingpain/post/repository/PostRepository.java
+++ b/src/main/java/cotato/growingpain/post/repository/PostRepository.java
@@ -5,12 +5,15 @@ import cotato.growingpain.post.domain.entity.Post;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByMemberId(Long memberId);
-    List<Post> findByParentCategory(PostCategory parentCategory);
-    List<Post> findBySubCategory(PostCategory subCategory);
+
+    @Query("SELECT p FROM Post p WHERE p.parentCategory = :category OR p.subCategory = :category")
+    List<Post> findByCategory(@Param("category") PostCategory category);
 
     Optional<Post> findByIdAndMemberId(Long postId, Long memberId);
 }

--- a/src/main/java/cotato/growingpain/post/service/PostService.java
+++ b/src/main/java/cotato/growingpain/post/service/PostService.java
@@ -44,11 +44,7 @@ public class PostService {
     }
 
     public List<Post> getPostsByCategory(PostCategory category){
-        if (category.getParent() == null) {
-            return postRepository.findByParentCategory(category);
-        } else {
-            return postRepository.findBySubCategory(category);
-        }
+        return postRepository.findByCategory(category);
     }
 
     public List<Post> getAllPosts() {


### PR DESCRIPTION
## ☁️ what to do 
- 자유게시판, 포트폴리오 카테고리에 해당하는 게시글 목록 반환 에러 해결
- findByCategory 기능 쿼리문으로 해결
- 게시글 목록 반환시 응답에 멤버 관한 내용 추가
