### PR TITLE
feat: 로그인 시 회원정보 반환되게 응답 추가

### DIFF
--- a/src/main/java/cotato/growingpain/auth/controller/AuthController.java
+++ b/src/main/java/cotato/growingpain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package cotato.growingpain.auth.controller;
 
+import cotato.growingpain.auth.dto.LoginResponse;
 import cotato.growingpain.auth.dto.request.ChangePasswordRequest;
 import cotato.growingpain.auth.dto.request.CompleteSignupRequest;
 import cotato.growingpain.auth.dto.request.DuplicateCheckRequest;
@@ -11,7 +12,6 @@ import cotato.growingpain.auth.dto.response.ResetPasswordResponse;
 import cotato.growingpain.auth.service.AuthService;
 import cotato.growingpain.auth.service.ValidateService;
 import cotato.growingpain.common.Response;
-import cotato.growingpain.security.jwt.Token;
 import cotato.growingpain.security.jwt.dto.request.ReissueRequest;
 import cotato.growingpain.security.jwt.dto.response.ReissueResponse;
 import cotato.growingpain.security.oauth.AuthProvider;
@@ -45,10 +45,10 @@ public class AuthController {
     private final ValidateService validateService;
 
     @Operation(summary = "일반 로그인", description = "회원가입 및 로그인을 위한 메소드")
-    @ApiResponse(content = @Content(schema = @Schema(implementation = Token.class)))
+    @ApiResponse(content = @Content(schema = @Schema(implementation = LoginResponse.class)))
     @PostMapping("/login/general")
     @ResponseStatus(HttpStatus.OK )
-    public Response<Token> joinAuth(@RequestBody @Valid LoginRequest request) {
+    public Response<LoginResponse> joinAuth(@RequestBody @Valid LoginRequest request) {
         log.info("[일반 로그인 컨트롤러]: {}", request.email());
         return Response.createSuccess("회원가입 및 로그인 완료", authService.createLoginInfo(AuthProvider.GENERAL, request));
     }

--- a/src/main/java/cotato/growingpain/auth/dto/LoginResponse.java
+++ b/src/main/java/cotato/growingpain/auth/dto/LoginResponse.java
@@ -1,0 +1,12 @@
+package cotato.growingpain.auth.dto;
+
+import cotato.growingpain.security.jwt.Token;
+
+public record LoginResponse(
+        Token token,
+        Long memberId,
+        String name,
+        String field,
+        String profileImageUrl
+) {
+}


### PR DESCRIPTION
## ⛓️ Related Issues
- https://github.com/IT-Cotato/9th-Growing-Pain-BE/issues/111#issue-2472576066

## ☁️ what to do 
-  로그인 시 회원정보 (회원 닉네임, 회원 분야, 회원 프로필 사진 url) 반환하게 응답 추가

## 💫 Changes in the project
- 회원가입 시 아래처럼 회원정보는 null로 반환
<img width="1440" alt="스크린샷 2024-08-19 오후 3 52 52" src="https://github.com/user-attachments/assets/6c1ac6a7-ee0d-4419-bfee-0ad588b52a80">

- 로그인 시 회원정보가 채워져서 반환
<img width="1440" alt="KakaoTalk_Photo_2024-08-19-16-01-08" src="https://github.com/user-attachments/assets/50d38e35-a196-48d8-9830-5782fee9b9c1">

