### PR TITLE
✨ Feat: s3를 이용한 프로필 이미지 업로드 구현

### DIFF
--- a/src/main/java/cotato/growingpain/member/controller/MemberController.java
+++ b/src/main/java/cotato/growingpain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package cotato.growingpain.member.controller;
 
 import cotato.growingpain.common.Response;
+import cotato.growingpain.common.exception.ImageException;
 import cotato.growingpain.member.dto.request.AdditionalInfoRequest;
 import cotato.growingpain.member.dto.request.UpdateDefaultInfoRequest;
 import cotato.growingpain.member.dto.request.UpdateMemberProfileShowingRequest;
@@ -21,8 +22,10 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "마이페이지", description = "마이페이지 관련된 api")
 @RestController
@@ -73,5 +76,16 @@ public class MemberController {
     public Response<MemberInfoResponse> getMemberInfo(@AuthenticationPrincipal Long memberId) {
         MemberInfoResponse memberInfo = memberService.getMemberInfo(memberId);
         return Response.createSuccess("[마이페이지] 프로필 공개 여부에 따른 정보 반환", memberInfo);
+    }
+
+    @Operation(summary = "프로필 이미지 등록", description = "멤버 프로필 이미지 등록 및 저장")
+    @ApiResponse(content = @Content(schema = @Schema(implementation = Response.class)))
+    @GetMapping("/profile-image")
+    @ResponseStatus(HttpStatus.OK)
+    public Response<?> registerProfileImage(@RequestParam("profile-image") MultipartFile profileImage,
+                                            @AuthenticationPrincipal Long memberId) throws ImageException {
+        log.info("프로필 이미지를 업로드한 memberId: {}", memberId);
+        memberService.registerProfileImage(memberId, profileImage);
+        return Response.createSuccessWithNoData("[마이페이지] 프로필 이미지 업로드 완료");
     }
 }

--- a/src/main/java/cotato/growingpain/member/domain/entity/Member.java
+++ b/src/main/java/cotato/growingpain/member/domain/entity/Member.java
@@ -183,16 +183,15 @@ public class Member extends BaseTimeEntity {
     }
 
     public void updateAdditionalInfo(String career, String aboutMe) {
-        this.educationBackground = educationBackground;
-        this.skill = skill;
-        this.activityHistory = activityHistory;
-        this.award = award;
-        this.languageScore = languageScore;
         this.career = career;
         this.aboutMe = aboutMe;
     }
 
     public void updateProfilePublic(MemberProfileShowing memberProfileShowing) {
         this.memberProfileShowing = memberProfileShowing;
+    }
+
+    public void updateProfileImage(String imageUrl) {
+        this.profileImageUrl = imageUrl;
     }
 }

--- a/src/main/java/cotato/growingpain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/cotato/growingpain/member/dto/response/MemberInfoResponse.java
@@ -5,6 +5,7 @@ import cotato.growingpain.member.domain.entity.Member;
 
 public record MemberInfoResponse(
         String name,
+        String profileImageUrl,
         String field,
         String belong,
         MemberJob job,
@@ -19,6 +20,7 @@ public record MemberInfoResponse(
     public static MemberInfoResponse fromMember(Member member) {
         return new MemberInfoResponse(
                 member.getName(),
+                member.getProfileImageUrl(),
                 member.getField(),
                 member.getBelong(),
                 member.getJob(),
@@ -35,6 +37,7 @@ public record MemberInfoResponse(
     public static MemberInfoResponse defaultInfoFromMember(Member member) {
         return new MemberInfoResponse(
                 member.getName(),
+                member.getProfileImageUrl(),
                 member.getField(),
                 member.getBelong(),
                 member.getJob(),

--- a/src/main/java/cotato/growingpain/member/service/MemberService.java
+++ b/src/main/java/cotato/growingpain/member/service/MemberService.java
@@ -2,16 +2,19 @@ package cotato.growingpain.member.service;
 
 import cotato.growingpain.common.exception.AppException;
 import cotato.growingpain.common.exception.ErrorCode;
+import cotato.growingpain.common.exception.ImageException;
 import cotato.growingpain.member.domain.MemberProfileShowing;
 import cotato.growingpain.member.domain.entity.Member;
 import cotato.growingpain.member.dto.request.AdditionalInfoRequest;
 import cotato.growingpain.member.dto.request.UpdateDefaultInfoRequest;
 import cotato.growingpain.member.dto.response.MemberInfoResponse;
 import cotato.growingpain.member.repository.MemberRepository;
+import cotato.growingpain.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
@@ -19,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final S3Uploader s3Uploader;
 
     @Transactional
     public void updateDefaultInfo(UpdateDefaultInfoRequest request, Long memberId) {
@@ -68,6 +72,18 @@ public class MemberService {
             return MemberInfoResponse.fromMember(member);
         } else {
             return MemberInfoResponse.defaultInfoFromMember(member);
+        }
+    }
+
+    @Transactional
+    public void registerProfileImage(Long memberId, MultipartFile profileImage) throws ImageException {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AppException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (profileImage != null && !profileImage.isEmpty()) {
+            String imageUrl = s3Uploader.uploadFileToS3(profileImage, "profile-image");
+            member.updateProfileImage(imageUrl);
+            memberRepository.save(member);
         }
     }
 }


### PR DESCRIPTION
## ⛓️ Related Issues
관련 이슈
- https://github.com/IT-Cotato/9th-Growing-Pain-BE/issues/140#issue-2542170848

## ☁️ what to do 
- 프로필 이미지 추가 및 수정 기능 구현
- 멤버 정보 목록에 프로필 이미지 url 추가